### PR TITLE
feat(webflow): ignore updateinfo product in webflow prepayment webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The functions provided in this repository are used independently.
 Be sure to check the README for each function in the functions folder, as they provide specific documentation.
 
 - Datastore integrations: 
-    - [datastore-integration-webflow](src/functions/pre-payment-webhook-webflow): Validates the price and/or availability of items against Webflow CMS collections before a payment is processed.
+    - [datastore-integration-webflow](src/functions/datastore-integration-webflow): Validates the price and/or availability of items against Webflow CMS collections before a payment is processed.
     - [datastore-integration-orderdesk](src/functions/datastore-integration-orderdesk): Validates the cart against OrderDesk and updates the inventory upon successful transaction.
 - Other features:
   - [cart](src/functions/cart): Converts a cart between recurring and non-recurring. Useful in an upsell flow.
@@ -117,6 +117,7 @@ This section contains all possible customizations you can do by setting environm
 |`FOXY_SKIP_INVENTORY_CODES`| [description in Foxy Webhook doc](src/foxy/README.md#environment-variables)|
 |`FOXY_SKIP_INVENTORY_UPDATE_CODES`| [description in Foxy Webhook doc](src/foxy/README.md#environment-variables)|
 |`FOXY_SKIP_PRICE_CODES`| [description in Foxy Webhook doc](src/foxy/README.md#environment-variables)|
+|`FOXY_SKIP_UPDATEINFO_NAME`| [description in Foxy Webhook doc](src/foxy/README.md#environment-variables)|
 |`FOXY_WEBFLOW_TOKEN`|[description in Idev Affiliate doc](src/functions/datastore-integration-webflow/README.md#environment-variables)|
 |`FOXY_WEBHOOK_ENCRYPTION_KEY`| [description in Foxy Webhook doc](src/foxy/README.md#environment-variables)|
 

--- a/config.js
+++ b/config.js
@@ -36,7 +36,8 @@ const config = {
     },
     skipValidation: {
       inventory: env('FOXY_SKIP_INVENTORY_CODES') || env('FX_SKIP_INVENTORY_CODES'),
-      price: env('FOXY_SKIP_PRICE_CODES') || env('FX_SKIP_PRICE_CODES')
+      price: env('FOXY_SKIP_PRICE_CODES') || env('FX_SKIP_PRICE_CODES'),
+      updateinfo: env('FOXY_SKIP_UPDATEINFO_NAME')
     },
   },
   default: {

--- a/src/foxy/README.md
+++ b/src/foxy/README.md
@@ -29,6 +29,7 @@ These environment variables are used to configure datastore functions.
 | `FOXY_SKIP_INVENTORY_CODES`         | ""\* | A comma separated list of code values (this is the value set in your 'code' field in Webflow or in the field you set with `code_field` parameter. **The items with these codes will skip inventory verification**. |
 | `FOXY_SKIP_PRICE_CODES`             | ""\* | A comma separated list of code values (this is the value set in your 'code' field in Webflow or in the field you set with `code_field` parameter. **The items with these codes will skip price verification**.     |
 | `FOXY_SKIP_INVENTORY_CODES`         | ""\* | A comma separated list of code values (this is the value set in your 'code' field in Webflow or in the field you set with `code_field` parameter. **The items with these codes will skip inventory verification**. |
+| `FOXY_SKIP_UPDATEINFO_NAME`         | "Update Your Customer Information" | The name of the `updateinfo` product for your store, to be ignored from any verifications. |
 
 \* These default values may be different for some functions.
 Please, check the specific documentation for the function you are using.

--- a/src/functions/datastore-integration-webflow/index.js
+++ b/src/functions/datastore-integration-webflow/index.js
@@ -22,6 +22,7 @@ function customOptions() {
     skip: {
       inventory: (config.datastore.skipValidation.inventory || '').split(',').map(e => e.trim()).filter(e => !!e) || [],
       price: (config.datastore.skipValidation.price || '').split(',').map(e => e.trim()).filter(e => !!e) || [],
+      updateinfo: config.datastore.skipValidation.updateinfo || 'Update Your Customer Information',
     },
     webflow: {
       limit: 100,
@@ -191,7 +192,7 @@ function createCache() {
 function extractItems(body) {
   const objBody = JSON.parse(body);
   if (objBody && objBody._embedded && objBody._embedded['fx:items']) {
-    return objBody._embedded['fx:items'];
+    return objBody._embedded['fx:items'].filter(item => item.name !== customOptions().skip.updateinfo);
   }
   return [];
 }


### PR DESCRIPTION
This is a quick change to add support for ignoring the "Update Your Customer Information" product within the Webflow pre-payment webhook. If not ignored, the updateinfo product will fail validations and prevent the checkout from being able to be completed.