### PR TITLE
Add customer name matching to the transaction blocking function

### DIFF
--- a/src/functions/block-transactions-on-customer-criteria/README.md
+++ b/src/functions/block-transactions-on-customer-criteria/README.md
@@ -14,7 +14,7 @@ Forking the repository will create your own copy of this Webhook, allowing you t
 
 ### Customize
 
-Modify the matchlist.json file to include the email addresses/ip addresses that you want to block. If you don't want to block based on one of those, you can leave the array empty. Note that the examples provided are for illustrative purposes only. It'll work as is, but blocking based on IP or email isn't necessarily a recommended approach.
+Modify the matchlist.json file to include the email addresses/ip addresses/customer names that you want to block. If you don't want to block based on one of those, you can leave the array empty. Note that the examples provided are for illustrative purposes only. It'll work as is, but blocking based on IP, email or name isn't necessarily a recommended approach.
 
 You can also modify the error message that's displayed to customers when the pre-payment webhook validation fails. The default message is "Sorry, the transaction cannot be completed." Do not remove the quotes enclosing the message.
 

--- a/src/functions/block-transactions-on-customer-criteria/matchlist.json
+++ b/src/functions/block-transactions-on-customer-criteria/matchlist.json
@@ -1,9 +1,13 @@
-{  "_comment": "Leave any arrays empty ([]) that you don't want to track.",
+{  "_comment": "Leave any arrays empty ([]) that you don't want to block.",
     "email_addresses": [
         "email@example.com",
         "email2@example.com"
     ],
     "ip_addresses": [
         "192.169.1.1"
+    ],
+    "customer_names": [
+        "John Doe",
+        "Jane Doe"
     ]
 }


### PR DESCRIPTION
This is a quick addition to the `block-transactions-on-customer-critera` function to also support restricting based on the customer name. It compares both the billing and shipping name against the names from the matchlist, doing a case insensitive comparison.